### PR TITLE
feat: add Push Credential SID to the Voice access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,14 @@ USAGE
   $ twilio token:voice
 
 OPTIONS
-  -l=(debug|info|warn|error|none)  [default: info] Level of logging messages.
-  -o=(columns|json|tsv)            [default: columns] Format of command output.
-  -p, --profile=profile            Shorthand identifier for your profile.
-  --allow-incoming=true|false      [default: true] Allow incoming calls (true/false) (defaults to true)
-  --identity=identity              (required) The user identity
-  --ttl=ttl                        Optional TTL for token (up to 24 hours) (value in seconds)
-  --voice-app-sid=voice-app-sid    (required) The TwiML Application SID for outbound calls, starts with APXXX
+  -l=(debug|info|warn|error|none)            [default: info] Level of logging messages.
+  -o=(columns|json|tsv)                      [default: columns] Format of command output.
+  -p, --profile=profile                      Shorthand identifier for your profile.
+  --allow-incoming=true|false                [default: true] Allow incoming calls (true/false) (defaults to true)
+  --identity=identity                        (required) The user identity
+  --ttl=ttl                                  Optional TTL for token (up to 24 hours) (value in seconds)
+  --voice-app-sid=voice-app-sid              (required) The TwiML Application SID for outbound calls, starts with APXXX
+  --push-credential-sid=push-credential-sid  The Push Credential SID for receiving incoming call push notifications, starts with CRXXX
 ```
 
 _See code: [src/commands/token/voice.js](https://github.com/twilio-labs/plugin-token/blob/v3.0.1/src/commands/token/voice.js)_

--- a/src/commands/token/voice.js
+++ b/src/commands/token/voice.js
@@ -23,11 +23,22 @@ class VoiceTokenGenerator extends TwilioClientCommand {
       process.exit(1);
     }
 
+    let pushCredentialSid = this.flags['push-credential-sid'];
+    if (pushCredentialSid && !validatePushCredentialSid(pushCredentialSid)) {
+      this.logger.error(
+        'Invalid Push Credential SID, must look like CRxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      );
+      process.exit(1);
+    }
+
     let incomingAllow = (this.flags['allow-incoming'] == 'true');
     let voiceGrant = new Twilio.jwt.AccessToken.VoiceGrant({
       outgoingApplicationSid: this.flags['voice-app-sid'],
       incomingAllow
     });
+    if (pushCredentialSid) {
+      voiceGrant.pushCredentialSid;
+    }
     accessToken.addGrant(voiceGrant);
 
     this.logger.info('Copy/paste this voice token into your test application:');

--- a/src/commands/token/voice.js
+++ b/src/commands/token/voice.js
@@ -37,7 +37,7 @@ class VoiceTokenGenerator extends TwilioClientCommand {
       incomingAllow
     });
     if (pushCredentialSid) {
-      voiceGrant.pushCredentialSid;
+      voiceGrant.pushCredentialSid = pushCredentialSid;
     }
     accessToken.addGrant(voiceGrant);
 

--- a/src/helpers/voiceGlobals.js
+++ b/src/helpers/voiceGlobals.js
@@ -10,6 +10,10 @@ const voiceFlags = {
     options: ['true', 'false'],
     default: 'true',
     required: false
+  }),
+  'push-credential-sid': flags.string({
+    description: 'The Push Credential SID for receiving incoming call push notifications, starts with CRXXX',
+    required: false
   })
 };
 
@@ -20,4 +24,11 @@ const validateTwimlAppSid = function(sid) {
   );
 }
 
-module.exports = { voiceFlags, validateTwimlAppSid };
+const validatePushCredentialSid = function(sid) {
+  return (
+    sid.startsWith('CR') &&
+    sid.length === 34
+  );
+}
+
+module.exports = { voiceFlags, validateTwimlAppSid, validatePushCredentialSid };


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

### Description

Adding Push Credential SID capability to the Voice Access Token. The optional SID (`CRxxx`) allows the Voice SDK mobile clients to register for the push notifications for incoming calls.

### Breakdown

- Add validation method for the Push Credential SID
- Add the Push Credential SID to the `VoiceGrant` if presented
- Add helper description
- Update README