### PR TITLE
fix: resolve manifest generation issues, update oclif tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generate a temporary token for use in a Twilio client-side SDK application
 * [Requirements](#requirements)
 * [Usage](#usage)
 * [Commands](#commands)
-* [ Contributing](#contributing)
+* [ Contributing](#-contributing)
 * [License](#license)
 <!-- tocstop -->
 # Requirements
@@ -39,141 +39,144 @@ USAGE
 
 ```
 USAGE
-  $ twilio token:capability:client
+  $ twilio token:capability:client --voice-app-sid <value> --identity <value> [-l (debug|info|warn|error|none)] [-o
+    (columns|json|tsv|none)] [--silent] [-p <value>] [--allow-incoming true|false] [--push-credential-sid <value>]
+    [--ttl <value>]
 
-OPTIONS
-  -l=(debug|info|warn|error|none)            [default: info] Level of logging messages.
-  -o=(columns|json|tsv|none)                 [default: columns] Format of command output.
-  -p, --profile=profile                      Shorthand identifier for your profile.
-  --allow-incoming=true|false                [default: true] Allow incoming calls (true/false) (defaults to true)
-  --identity=identity                        (required) The user identity
-
-  --push-credential-sid=push-credential-sid  The Push Credential SID for receiving incoming call push notifications,
-                                             starts with CRXXX
-
-  --silent                                   Suppress output and logs. This is a shorthand for "-l none -o none".
-
-  --ttl=ttl                                  Optional TTL for token (up to 24 hours) (value in seconds)
-
-  --voice-app-sid=voice-app-sid              (required) The TwiML Application SID for outbound calls, starts with APXXX
+FLAGS
+  -l=(debug|info|warn|error|none)    [default: info] Level of logging messages.
+  -o=(columns|json|tsv|none)         [default: columns] Format of command output.
+  -p, --profile=<value>              Shorthand identifier for your profile.
+      --allow-incoming=<option>      [default: true] Allow incoming calls (true/false) (defaults to true)
+                                     <options: true|false>
+      --identity=<value>             (required) The user identity
+      --push-credential-sid=<value>  The Push Credential SID for receiving incoming call push notifications, starts with
+                                     CRXXX
+      --silent                       Suppress  output and logs. This is a shorthand for "-l none -o none".
+      --ttl=<value>                  Optional TTL for token (up to 24 hours) (value in seconds)
+      --voice-app-sid=<value>        (required) The TwiML Application SID for outbound calls, starts with APXXX
 ```
 
-_See code: [src/commands/token/capability/client.js](https://github.com/twilio-labs/plugin-token/blob/v4.0.0/src/commands/token/capability/client.js)_
+_See code: [src/commands/token/capability/client.js](https://github.com/twilio-labs/plugin-token/blob/v6.0.0/src/commands/token/capability/client.js)_
 
 ## `twilio token:capability:worker`
 
 ```
 USAGE
-  $ twilio token:capability:worker
+  $ twilio token:capability:worker --worker-sid <value> --workspace-sid <value> [-l (debug|info|warn|error|none)] [-o
+    (columns|json|tsv|none)] [--silent] [-p <value>] [--ttl <value>]
 
-OPTIONS
+FLAGS
   -l=(debug|info|warn|error|none)  [default: info] Level of logging messages.
   -o=(columns|json|tsv|none)       [default: columns] Format of command output.
-  -p, --profile=profile            Shorthand identifier for your profile.
-  --silent                         Suppress output and logs. This is a shorthand for "-l none -o none".
-  --ttl=ttl                        Optional TTL for token (up to 24 hours) (value in seconds)
-  --worker-sid=worker-sid          (required) The Worker SID for this token
-  --workspace-sid=workspace-sid    (required) The Workspace SID for this token
+  -p, --profile=<value>            Shorthand identifier for your profile.
+      --silent                     Suppress  output and logs. This is a shorthand for "-l none -o none".
+      --ttl=<value>                Optional TTL for token (up to 24 hours) (value in seconds)
+      --worker-sid=<value>         (required) The Worker SID for this token
+      --workspace-sid=<value>      (required) The Workspace SID for this token
 ```
 
-_See code: [src/commands/token/capability/worker.js](https://github.com/twilio-labs/plugin-token/blob/v4.0.0/src/commands/token/capability/worker.js)_
+_See code: [src/commands/token/capability/worker.js](https://github.com/twilio-labs/plugin-token/blob/v6.0.0/src/commands/token/capability/worker.js)_
 
 ## `twilio token:chat`
 
 ```
 USAGE
-  $ twilio token:chat
+  $ twilio token:chat --identity <value> --chat-service-sid <value> [-l (debug|info|warn|error|none)] [-o
+    (columns|json|tsv|none)] [--silent] [-p <value>] [--ttl <value>]
 
-OPTIONS
-  -l=(debug|info|warn|error|none)      [default: info] Level of logging messages.
-  -o=(columns|json|tsv|none)           [default: columns] Format of command output.
-  -p, --profile=profile                Shorthand identifier for your profile.
-  --chat-service-sid=chat-service-sid  (required) The service SID for the Chat, starts with ISXXX
-  --identity=identity                  (required) The user identity
-  --silent                             Suppress output and logs. This is a shorthand for "-l none -o none".
-  --ttl=ttl                            Optional TTL for token (up to 24 hours) (value in seconds)
+FLAGS
+  -l=(debug|info|warn|error|none)  [default: info] Level of logging messages.
+  -o=(columns|json|tsv|none)       [default: columns] Format of command output.
+  -p, --profile=<value>            Shorthand identifier for your profile.
+      --chat-service-sid=<value>   (required) The service SID for the Chat, starts with ISXXX
+      --identity=<value>           (required) The user identity
+      --silent                     Suppress  output and logs. This is a shorthand for "-l none -o none".
+      --ttl=<value>                Optional TTL for token (up to 24 hours) (value in seconds)
 ```
 
-_See code: [src/commands/token/chat.js](https://github.com/twilio-labs/plugin-token/blob/v4.0.0/src/commands/token/chat.js)_
+_See code: [src/commands/token/chat.js](https://github.com/twilio-labs/plugin-token/blob/v6.0.0/src/commands/token/chat.js)_
 
 ## `twilio token:flex`
 
 ```
 USAGE
-  $ twilio token:flex
+  $ twilio token:flex --worker-sid <value> --workspace-sid <value> [-l (debug|info|warn|error|none)] [-o
+    (columns|json|tsv|none)] [--silent] [-p <value>] [--ttl <value>]
 
-OPTIONS
+FLAGS
   -l=(debug|info|warn|error|none)  [default: info] Level of logging messages.
   -o=(columns|json|tsv|none)       [default: columns] Format of command output.
-  -p, --profile=profile            Shorthand identifier for your profile.
-  --silent                         Suppress output and logs. This is a shorthand for "-l none -o none".
-  --ttl=ttl                        Optional TTL for token (up to 24 hours) (value in seconds)
-  --worker-sid=worker-sid          (required) The Worker SID for this token
-  --workspace-sid=workspace-sid    (required) The Workspace SID for this token
+  -p, --profile=<value>            Shorthand identifier for your profile.
+      --silent                     Suppress  output and logs. This is a shorthand for "-l none -o none".
+      --ttl=<value>                Optional TTL for token (up to 24 hours) (value in seconds)
+      --worker-sid=<value>         (required) The Worker SID for this token
+      --workspace-sid=<value>      (required) The Workspace SID for this token
 ```
 
-_See code: [src/commands/token/flex.js](https://github.com/twilio-labs/plugin-token/blob/v4.0.0/src/commands/token/flex.js)_
+_See code: [src/commands/token/flex.js](https://github.com/twilio-labs/plugin-token/blob/v6.0.0/src/commands/token/flex.js)_
 
 ## `twilio token:sync`
 
 ```
 USAGE
-  $ twilio token:sync
+  $ twilio token:sync --identity <value> --sync-service-sid <value> [-l (debug|info|warn|error|none)] [-o
+    (columns|json|tsv|none)] [--silent] [-p <value>] [--ttl <value>]
 
-OPTIONS
-  -l=(debug|info|warn|error|none)      [default: info] Level of logging messages.
-  -o=(columns|json|tsv|none)           [default: columns] Format of command output.
-  -p, --profile=profile                Shorthand identifier for your profile.
-  --identity=identity                  (required) The user identity
-  --silent                             Suppress output and logs. This is a shorthand for "-l none -o none".
-  --sync-service-sid=sync-service-sid  (required) The service SID for the Sync, starts with ISXXX
-  --ttl=ttl                            Optional TTL for token (up to 24 hours) (value in seconds)
+FLAGS
+  -l=(debug|info|warn|error|none)  [default: info] Level of logging messages.
+  -o=(columns|json|tsv|none)       [default: columns] Format of command output.
+  -p, --profile=<value>            Shorthand identifier for your profile.
+      --identity=<value>           (required) The user identity
+      --silent                     Suppress  output and logs. This is a shorthand for "-l none -o none".
+      --sync-service-sid=<value>   (required) The service SID for the Sync, starts with ISXXX
+      --ttl=<value>                Optional TTL for token (up to 24 hours) (value in seconds)
 ```
 
-_See code: [src/commands/token/sync.js](https://github.com/twilio-labs/plugin-token/blob/v4.0.0/src/commands/token/sync.js)_
+_See code: [src/commands/token/sync.js](https://github.com/twilio-labs/plugin-token/blob/v6.0.0/src/commands/token/sync.js)_
 
 ## `twilio token:video`
 
 ```
 USAGE
-  $ twilio token:video
+  $ twilio token:video --identity <value> [-l (debug|info|warn|error|none)] [-o (columns|json|tsv|none)]
+    [--silent] [-p <value>] [--room-name <value>] [--ttl <value>]
 
-OPTIONS
+FLAGS
   -l=(debug|info|warn|error|none)  [default: info] Level of logging messages.
   -o=(columns|json|tsv|none)       [default: columns] Format of command output.
-  -p, --profile=profile            Shorthand identifier for your profile.
-  --identity=identity              (required) The user identity
-  --room-name=room-name            The name of the room this token grants access to
-  --silent                         Suppress output and logs. This is a shorthand for "-l none -o none".
-  --ttl=ttl                        Optional TTL for token (up to 24 hours) (value in seconds)
+  -p, --profile=<value>            Shorthand identifier for your profile.
+      --identity=<value>           (required) The user identity
+      --room-name=<value>          The name of the room this token grants access to
+      --silent                     Suppress  output and logs. This is a shorthand for "-l none -o none".
+      --ttl=<value>                Optional TTL for token (up to 24 hours) (value in seconds)
 ```
 
-_See code: [src/commands/token/video.js](https://github.com/twilio-labs/plugin-token/blob/v4.0.0/src/commands/token/video.js)_
+_See code: [src/commands/token/video.js](https://github.com/twilio-labs/plugin-token/blob/v6.0.0/src/commands/token/video.js)_
 
 ## `twilio token:voice`
 
 ```
 USAGE
-  $ twilio token:voice
+  $ twilio token:voice --voice-app-sid <value> --identity <value> [-l (debug|info|warn|error|none)] [-o
+    (columns|json|tsv|none)] [--silent] [-p <value>] [--allow-incoming true|false] [--push-credential-sid <value>]
+    [--ttl <value>]
 
-OPTIONS
-  -l=(debug|info|warn|error|none)            [default: info] Level of logging messages.
-  -o=(columns|json|tsv|none)                 [default: columns] Format of command output.
-  -p, --profile=profile                      Shorthand identifier for your profile.
-  --allow-incoming=true|false                [default: true] Allow incoming calls (true/false) (defaults to true)
-  --identity=identity                        (required) The user identity
-
-  --push-credential-sid=push-credential-sid  The Push Credential SID for receiving incoming call push notifications,
-                                             starts with CRXXX
-
-  --silent                                   Suppress output and logs. This is a shorthand for "-l none -o none".
-
-  --ttl=ttl                                  Optional TTL for token (up to 24 hours) (value in seconds)
-
-  --voice-app-sid=voice-app-sid              (required) The TwiML Application SID for outbound calls, starts with APXXX
+FLAGS
+  -l=(debug|info|warn|error|none)    [default: info] Level of logging messages.
+  -o=(columns|json|tsv|none)         [default: columns] Format of command output.
+  -p, --profile=<value>              Shorthand identifier for your profile.
+      --allow-incoming=<option>      [default: true] Allow incoming calls (true/false) (defaults to true)
+                                     <options: true|false>
+      --identity=<value>             (required) The user identity
+      --push-credential-sid=<value>  The Push Credential SID for receiving incoming call push notifications, starts with
+                                     CRXXX
+      --silent                       Suppress  output and logs. This is a shorthand for "-l none -o none".
+      --ttl=<value>                  Optional TTL for token (up to 24 hours) (value in seconds)
+      --voice-app-sid=<value>        (required) The TwiML Application SID for outbound calls, starts with APXXX
 ```
 
-_See code: [src/commands/token/voice.js](https://github.com/twilio-labs/plugin-token/blob/v4.0.0/src/commands/token/voice.js)_
+_See code: [src/commands/token/voice.js](https://github.com/twilio-labs/plugin-token/blob/v6.0.0/src/commands/token/voice.js)_
 <!-- commandsstop -->
 #  Contributing
 

--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,10 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"performance": {
+        "noDelete": "warn"
+      }
 		}
 	}
 }

--- a/biome.json
+++ b/biome.json
@@ -13,8 +13,8 @@
 		"rules": {
 			"recommended": true,
 			"performance": {
-        "noDelete": "warn"
-      }
+				"noDelete": "warn"
+			}
 		}
 	}
 }

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,0 +1,818 @@
+{
+	"commands": {
+		"token:chat": {
+			"aliases": [],
+			"args": {},
+			"flags": {
+				"cli-log-level": {
+					"char": "l",
+					"description": "Level of logging messages.",
+					"helpLabel": "-l",
+					"name": "cli-log-level",
+					"default": "info",
+					"hasDynamicHelp": false,
+					"helpValue": "(debug|info|warn|error|none)",
+					"multiple": false,
+					"options": ["debug", "info", "warn", "error", "none"],
+					"type": "option"
+				},
+				"cli-output-format": {
+					"char": "o",
+					"description": "Format of command output.",
+					"helpLabel": "-o",
+					"name": "cli-output-format",
+					"default": "columns",
+					"hasDynamicHelp": false,
+					"helpValue": "(columns|json|tsv|none)",
+					"multiple": false,
+					"options": ["columns", "json", "tsv", "none"],
+					"type": "option"
+				},
+				"silent": {
+					"description": "Suppress  output and logs. This is a shorthand for \"-l none -o none\".",
+					"name": "silent",
+					"allowNo": false,
+					"type": "boolean"
+				},
+				"profile": {
+					"char": "p",
+					"description": "Shorthand identifier for your profile.",
+					"name": "profile",
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"identity": {
+					"description": "The user identity",
+					"name": "identity",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"chat-service-sid": {
+					"description": "The service SID for the Chat, starts with ISXXX",
+					"name": "chat-service-sid",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"ttl": {
+					"description": "Optional TTL for token (up to 24 hours) (value in seconds)",
+					"name": "ttl",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"hasDynamicHelp": false,
+			"hiddenAliases": [],
+			"id": "token:chat",
+			"pluginAlias": "@twilio-labs/plugin-token",
+			"pluginName": "@twilio-labs/plugin-token",
+			"pluginType": "core",
+			"strict": true,
+			"parse": true,
+			"parserOptions": {},
+			"accountSidFlag": {
+				"account-sid": {
+					"description": "Access resources for the specified account.",
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"limitFlags": {
+				"limit": {
+					"description": "The maximum number of resources to return. Use '--no-limit' to disable.",
+					"default": 50,
+					"exclusive": ["no-limit"],
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				},
+				"no-limit": {
+					"default": false,
+					"hidden": true,
+					"exclusive": ["limit"],
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"noHeader": {
+				"no-header": {
+					"description": "Skip including of headers while listing the data.",
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"isESM": false,
+			"relativePath": ["src", "commands", "token", "chat.js"]
+		},
+		"token:flex": {
+			"aliases": [],
+			"args": {},
+			"flags": {
+				"cli-log-level": {
+					"char": "l",
+					"description": "Level of logging messages.",
+					"helpLabel": "-l",
+					"name": "cli-log-level",
+					"default": "info",
+					"hasDynamicHelp": false,
+					"helpValue": "(debug|info|warn|error|none)",
+					"multiple": false,
+					"options": ["debug", "info", "warn", "error", "none"],
+					"type": "option"
+				},
+				"cli-output-format": {
+					"char": "o",
+					"description": "Format of command output.",
+					"helpLabel": "-o",
+					"name": "cli-output-format",
+					"default": "columns",
+					"hasDynamicHelp": false,
+					"helpValue": "(columns|json|tsv|none)",
+					"multiple": false,
+					"options": ["columns", "json", "tsv", "none"],
+					"type": "option"
+				},
+				"silent": {
+					"description": "Suppress  output and logs. This is a shorthand for \"-l none -o none\".",
+					"name": "silent",
+					"allowNo": false,
+					"type": "boolean"
+				},
+				"profile": {
+					"char": "p",
+					"description": "Shorthand identifier for your profile.",
+					"name": "profile",
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"worker-sid": {
+					"description": "The Worker SID for this token",
+					"name": "worker-sid",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"workspace-sid": {
+					"description": "The Workspace SID for this token",
+					"name": "workspace-sid",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"ttl": {
+					"description": "Optional TTL for token (up to 24 hours) (value in seconds)",
+					"name": "ttl",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"hasDynamicHelp": false,
+			"hiddenAliases": [],
+			"id": "token:flex",
+			"pluginAlias": "@twilio-labs/plugin-token",
+			"pluginName": "@twilio-labs/plugin-token",
+			"pluginType": "core",
+			"strict": true,
+			"parse": true,
+			"parserOptions": {},
+			"accountSidFlag": {
+				"account-sid": {
+					"description": "Access resources for the specified account.",
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"limitFlags": {
+				"limit": {
+					"description": "The maximum number of resources to return. Use '--no-limit' to disable.",
+					"default": 50,
+					"exclusive": ["no-limit"],
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				},
+				"no-limit": {
+					"default": false,
+					"hidden": true,
+					"exclusive": ["limit"],
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"noHeader": {
+				"no-header": {
+					"description": "Skip including of headers while listing the data.",
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"isESM": false,
+			"relativePath": ["src", "commands", "token", "flex.js"]
+		},
+		"token:sync": {
+			"aliases": [],
+			"args": {},
+			"flags": {
+				"cli-log-level": {
+					"char": "l",
+					"description": "Level of logging messages.",
+					"helpLabel": "-l",
+					"name": "cli-log-level",
+					"default": "info",
+					"hasDynamicHelp": false,
+					"helpValue": "(debug|info|warn|error|none)",
+					"multiple": false,
+					"options": ["debug", "info", "warn", "error", "none"],
+					"type": "option"
+				},
+				"cli-output-format": {
+					"char": "o",
+					"description": "Format of command output.",
+					"helpLabel": "-o",
+					"name": "cli-output-format",
+					"default": "columns",
+					"hasDynamicHelp": false,
+					"helpValue": "(columns|json|tsv|none)",
+					"multiple": false,
+					"options": ["columns", "json", "tsv", "none"],
+					"type": "option"
+				},
+				"silent": {
+					"description": "Suppress  output and logs. This is a shorthand for \"-l none -o none\".",
+					"name": "silent",
+					"allowNo": false,
+					"type": "boolean"
+				},
+				"profile": {
+					"char": "p",
+					"description": "Shorthand identifier for your profile.",
+					"name": "profile",
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"identity": {
+					"description": "The user identity",
+					"name": "identity",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"sync-service-sid": {
+					"description": "The service SID for the Sync, starts with ISXXX",
+					"name": "sync-service-sid",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"ttl": {
+					"description": "Optional TTL for token (up to 24 hours) (value in seconds)",
+					"name": "ttl",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"hasDynamicHelp": false,
+			"hiddenAliases": [],
+			"id": "token:sync",
+			"pluginAlias": "@twilio-labs/plugin-token",
+			"pluginName": "@twilio-labs/plugin-token",
+			"pluginType": "core",
+			"strict": true,
+			"parse": true,
+			"parserOptions": {},
+			"accountSidFlag": {
+				"account-sid": {
+					"description": "Access resources for the specified account.",
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"limitFlags": {
+				"limit": {
+					"description": "The maximum number of resources to return. Use '--no-limit' to disable.",
+					"default": 50,
+					"exclusive": ["no-limit"],
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				},
+				"no-limit": {
+					"default": false,
+					"hidden": true,
+					"exclusive": ["limit"],
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"noHeader": {
+				"no-header": {
+					"description": "Skip including of headers while listing the data.",
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"isESM": false,
+			"relativePath": ["src", "commands", "token", "sync.js"]
+		},
+		"token:video": {
+			"aliases": [],
+			"args": {},
+			"flags": {
+				"cli-log-level": {
+					"char": "l",
+					"description": "Level of logging messages.",
+					"helpLabel": "-l",
+					"name": "cli-log-level",
+					"default": "info",
+					"hasDynamicHelp": false,
+					"helpValue": "(debug|info|warn|error|none)",
+					"multiple": false,
+					"options": ["debug", "info", "warn", "error", "none"],
+					"type": "option"
+				},
+				"cli-output-format": {
+					"char": "o",
+					"description": "Format of command output.",
+					"helpLabel": "-o",
+					"name": "cli-output-format",
+					"default": "columns",
+					"hasDynamicHelp": false,
+					"helpValue": "(columns|json|tsv|none)",
+					"multiple": false,
+					"options": ["columns", "json", "tsv", "none"],
+					"type": "option"
+				},
+				"silent": {
+					"description": "Suppress  output and logs. This is a shorthand for \"-l none -o none\".",
+					"name": "silent",
+					"allowNo": false,
+					"type": "boolean"
+				},
+				"profile": {
+					"char": "p",
+					"description": "Shorthand identifier for your profile.",
+					"name": "profile",
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"room-name": {
+					"description": "The name of the room this token grants access to",
+					"name": "room-name",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"identity": {
+					"description": "The user identity",
+					"name": "identity",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"ttl": {
+					"description": "Optional TTL for token (up to 24 hours) (value in seconds)",
+					"name": "ttl",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"hasDynamicHelp": false,
+			"hiddenAliases": [],
+			"id": "token:video",
+			"pluginAlias": "@twilio-labs/plugin-token",
+			"pluginName": "@twilio-labs/plugin-token",
+			"pluginType": "core",
+			"strict": true,
+			"parse": true,
+			"parserOptions": {},
+			"accountSidFlag": {
+				"account-sid": {
+					"description": "Access resources for the specified account.",
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"limitFlags": {
+				"limit": {
+					"description": "The maximum number of resources to return. Use '--no-limit' to disable.",
+					"default": 50,
+					"exclusive": ["no-limit"],
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				},
+				"no-limit": {
+					"default": false,
+					"hidden": true,
+					"exclusive": ["limit"],
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"noHeader": {
+				"no-header": {
+					"description": "Skip including of headers while listing the data.",
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"isESM": false,
+			"relativePath": ["src", "commands", "token", "video.js"]
+		},
+		"token:voice": {
+			"aliases": [],
+			"args": {},
+			"flags": {
+				"cli-log-level": {
+					"char": "l",
+					"description": "Level of logging messages.",
+					"helpLabel": "-l",
+					"name": "cli-log-level",
+					"default": "info",
+					"hasDynamicHelp": false,
+					"helpValue": "(debug|info|warn|error|none)",
+					"multiple": false,
+					"options": ["debug", "info", "warn", "error", "none"],
+					"type": "option"
+				},
+				"cli-output-format": {
+					"char": "o",
+					"description": "Format of command output.",
+					"helpLabel": "-o",
+					"name": "cli-output-format",
+					"default": "columns",
+					"hasDynamicHelp": false,
+					"helpValue": "(columns|json|tsv|none)",
+					"multiple": false,
+					"options": ["columns", "json", "tsv", "none"],
+					"type": "option"
+				},
+				"silent": {
+					"description": "Suppress  output and logs. This is a shorthand for \"-l none -o none\".",
+					"name": "silent",
+					"allowNo": false,
+					"type": "boolean"
+				},
+				"profile": {
+					"char": "p",
+					"description": "Shorthand identifier for your profile.",
+					"name": "profile",
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"voice-app-sid": {
+					"description": "The TwiML Application SID for outbound calls, starts with APXXX",
+					"name": "voice-app-sid",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"allow-incoming": {
+					"description": "Allow incoming calls (true/false) (defaults to true)",
+					"name": "allow-incoming",
+					"required": false,
+					"default": "true",
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"options": ["true", "false"],
+					"type": "option"
+				},
+				"push-credential-sid": {
+					"description": "The Push Credential SID for receiving incoming call push notifications, starts with CRXXX",
+					"name": "push-credential-sid",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"identity": {
+					"description": "The user identity",
+					"name": "identity",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"ttl": {
+					"description": "Optional TTL for token (up to 24 hours) (value in seconds)",
+					"name": "ttl",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"hasDynamicHelp": false,
+			"hiddenAliases": [],
+			"id": "token:voice",
+			"pluginAlias": "@twilio-labs/plugin-token",
+			"pluginName": "@twilio-labs/plugin-token",
+			"pluginType": "core",
+			"strict": true,
+			"parse": true,
+			"parserOptions": {},
+			"accountSidFlag": {
+				"account-sid": {
+					"description": "Access resources for the specified account.",
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"limitFlags": {
+				"limit": {
+					"description": "The maximum number of resources to return. Use '--no-limit' to disable.",
+					"default": 50,
+					"exclusive": ["no-limit"],
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				},
+				"no-limit": {
+					"default": false,
+					"hidden": true,
+					"exclusive": ["limit"],
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"noHeader": {
+				"no-header": {
+					"description": "Skip including of headers while listing the data.",
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"isESM": false,
+			"relativePath": ["src", "commands", "token", "voice.js"]
+		},
+		"token:capability:client": {
+			"aliases": [],
+			"args": {},
+			"flags": {
+				"cli-log-level": {
+					"char": "l",
+					"description": "Level of logging messages.",
+					"helpLabel": "-l",
+					"name": "cli-log-level",
+					"default": "info",
+					"hasDynamicHelp": false,
+					"helpValue": "(debug|info|warn|error|none)",
+					"multiple": false,
+					"options": ["debug", "info", "warn", "error", "none"],
+					"type": "option"
+				},
+				"cli-output-format": {
+					"char": "o",
+					"description": "Format of command output.",
+					"helpLabel": "-o",
+					"name": "cli-output-format",
+					"default": "columns",
+					"hasDynamicHelp": false,
+					"helpValue": "(columns|json|tsv|none)",
+					"multiple": false,
+					"options": ["columns", "json", "tsv", "none"],
+					"type": "option"
+				},
+				"silent": {
+					"description": "Suppress  output and logs. This is a shorthand for \"-l none -o none\".",
+					"name": "silent",
+					"allowNo": false,
+					"type": "boolean"
+				},
+				"profile": {
+					"char": "p",
+					"description": "Shorthand identifier for your profile.",
+					"name": "profile",
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"voice-app-sid": {
+					"description": "The TwiML Application SID for outbound calls, starts with APXXX",
+					"name": "voice-app-sid",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"allow-incoming": {
+					"description": "Allow incoming calls (true/false) (defaults to true)",
+					"name": "allow-incoming",
+					"required": false,
+					"default": "true",
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"options": ["true", "false"],
+					"type": "option"
+				},
+				"push-credential-sid": {
+					"description": "The Push Credential SID for receiving incoming call push notifications, starts with CRXXX",
+					"name": "push-credential-sid",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"identity": {
+					"description": "The user identity",
+					"name": "identity",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"ttl": {
+					"description": "Optional TTL for token (up to 24 hours) (value in seconds)",
+					"name": "ttl",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"hasDynamicHelp": false,
+			"hiddenAliases": [],
+			"id": "token:capability:client",
+			"pluginAlias": "@twilio-labs/plugin-token",
+			"pluginName": "@twilio-labs/plugin-token",
+			"pluginType": "core",
+			"strict": true,
+			"parse": true,
+			"parserOptions": {},
+			"accountSidFlag": {
+				"account-sid": {
+					"description": "Access resources for the specified account.",
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"limitFlags": {
+				"limit": {
+					"description": "The maximum number of resources to return. Use '--no-limit' to disable.",
+					"default": 50,
+					"exclusive": ["no-limit"],
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				},
+				"no-limit": {
+					"default": false,
+					"hidden": true,
+					"exclusive": ["limit"],
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"noHeader": {
+				"no-header": {
+					"description": "Skip including of headers while listing the data.",
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"isESM": false,
+			"relativePath": ["src", "commands", "token", "capability", "client.js"]
+		},
+		"token:capability:worker": {
+			"aliases": [],
+			"args": {},
+			"flags": {
+				"cli-log-level": {
+					"char": "l",
+					"description": "Level of logging messages.",
+					"helpLabel": "-l",
+					"name": "cli-log-level",
+					"default": "info",
+					"hasDynamicHelp": false,
+					"helpValue": "(debug|info|warn|error|none)",
+					"multiple": false,
+					"options": ["debug", "info", "warn", "error", "none"],
+					"type": "option"
+				},
+				"cli-output-format": {
+					"char": "o",
+					"description": "Format of command output.",
+					"helpLabel": "-o",
+					"name": "cli-output-format",
+					"default": "columns",
+					"hasDynamicHelp": false,
+					"helpValue": "(columns|json|tsv|none)",
+					"multiple": false,
+					"options": ["columns", "json", "tsv", "none"],
+					"type": "option"
+				},
+				"silent": {
+					"description": "Suppress  output and logs. This is a shorthand for \"-l none -o none\".",
+					"name": "silent",
+					"allowNo": false,
+					"type": "boolean"
+				},
+				"profile": {
+					"char": "p",
+					"description": "Shorthand identifier for your profile.",
+					"name": "profile",
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"worker-sid": {
+					"description": "The Worker SID for this token",
+					"name": "worker-sid",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"workspace-sid": {
+					"description": "The Workspace SID for this token",
+					"name": "workspace-sid",
+					"required": true,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				},
+				"ttl": {
+					"description": "Optional TTL for token (up to 24 hours) (value in seconds)",
+					"name": "ttl",
+					"required": false,
+					"hasDynamicHelp": false,
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"hasDynamicHelp": false,
+			"hiddenAliases": [],
+			"id": "token:capability:worker",
+			"pluginAlias": "@twilio-labs/plugin-token",
+			"pluginName": "@twilio-labs/plugin-token",
+			"pluginType": "core",
+			"strict": true,
+			"parse": true,
+			"parserOptions": {},
+			"accountSidFlag": {
+				"account-sid": {
+					"description": "Access resources for the specified account.",
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				}
+			},
+			"limitFlags": {
+				"limit": {
+					"description": "The maximum number of resources to return. Use '--no-limit' to disable.",
+					"default": 50,
+					"exclusive": ["no-limit"],
+					"input": [],
+					"multiple": false,
+					"type": "option"
+				},
+				"no-limit": {
+					"default": false,
+					"hidden": true,
+					"exclusive": ["limit"],
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"noHeader": {
+				"no-header": {
+					"description": "Skip including of headers while listing the data.",
+					"allowNo": false,
+					"type": "boolean"
+				}
+			},
+			"isESM": false,
+			"relativePath": ["src", "commands", "token", "capability", "worker.js"]
+		}
+	},
+	"version": "6.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"biome:lint:write": "npx @biomejs/biome lint --write .",
 		"coverage": "nyc --check-coverage --lines 90 --reporter=html --reporter=text mocha --forbid-only \"test/**/*.test.js\"",
 		"oclif:manifest": "oclif manifest",
-		"oclif:readme": "oclif manifest",
+		"oclif:readme": "oclif readme",
 		"postpack": "rm -f oclif.manifest.json",
 		"prepack": "npm run oclif:manifest && oclif:readme",
 		"test": "mocha --forbid-only \"test/**/*.test.js\""

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"globby": "^8.0.2",
 		"mocha": "^8.2.1",
 		"nyc": "^14.1.1",
+		"oclif": "^4.17.32",
 		"sinon": "^9.2.1"
 	},
 	"engines": {
@@ -31,13 +32,17 @@
 		"/yarn.lock"
 	],
 	"homepage": "https://github.com/twilio-labs/plugin-token",
-	"keywords": ["oclif-plugin"],
+	"keywords": [
+		"oclif-plugin"
+	],
 	"license": "MIT",
 	"oclif": {
 		"name": "token",
 		"commands": "./src/commands",
 		"bin": "twilio",
-		"devPlugins": ["@oclif/plugin-help"],
+		"devPlugins": [
+			"@oclif/plugin-help"
+		],
 		"topics": {
 			"token": {
 				"description": "Generate a temporary token for use in test applications"
@@ -60,8 +65,10 @@
 		"biome:lint": "npx @biomejs/biome lint .",
 		"biome:lint:write": "npx @biomejs/biome lint --write .",
 		"coverage": "nyc --check-coverage --lines 90 --reporter=html --reporter=text mocha --forbid-only \"test/**/*.test.js\"",
+		"oclif:manifest": "oclif manifest",
+		"oclif:readme": "oclif manifest",
 		"postpack": "rm -f oclif.manifest.json",
-		"prepack": "oclif-dev manifest && oclif-dev readme",
+		"prepack": "npm run oclif:manifest && oclif:readme",
 		"test": "mocha --forbid-only \"test/**/*.test.js\""
 	}
 }

--- a/package.json
+++ b/package.json
@@ -32,17 +32,13 @@
 		"/yarn.lock"
 	],
 	"homepage": "https://github.com/twilio-labs/plugin-token",
-	"keywords": [
-		"oclif-plugin"
-	],
+	"keywords": ["oclif-plugin"],
 	"license": "MIT",
 	"oclif": {
 		"name": "token",
 		"commands": "./src/commands",
 		"bin": "twilio",
-		"devPlugins": [
-			"@oclif/plugin-help"
-		],
+		"devPlugins": ["@oclif/plugin-help"],
 		"topics": {
 			"token": {
 				"description": "Generate a temporary token for use in test applications"

--- a/src/commands/token/capability/worker.js
+++ b/src/commands/token/capability/worker.js
@@ -107,7 +107,7 @@ class WorkerCapabilityTokenGenerator extends TwilioClientCommand {
 }
 
 const globals = { ...globalFlags };
-globals.identity = undefined;
+delete globals.identity;
 
 WorkerCapabilityTokenGenerator.flags = Object.assign(
 	taskrouterFlags,

--- a/src/commands/token/flex.js
+++ b/src/commands/token/flex.js
@@ -49,7 +49,7 @@ class FlexTokenGenerator extends TwilioClientCommand {
 }
 
 const globals = { ...globalFlags };
-globals.identity = undefined;
+delete globals.identity;
 
 FlexTokenGenerator.flags = Object.assign(
 	taskrouterFlags,


### PR DESCRIPTION
<!-- Describe your Pull Request -->

This PR resovles manifest generation issues. Specifically, it reverts two changes that were made to remove using `delete` with variables, assigning them to `undefined` instead. I've also updated biome to `warn` rather than `error` on these instances - we do want to change the instances of `delete` eventually, but it's fine to keep them in for now. I've also run the readme update tool that oclif provides, which has implemented a number of changes.

Additionally, I've updated `oclif` tooling to use the versions supported by oclif now and have added npm scripts so we don't have to remember which commands we need to run.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
