### PR TITLE
Avoid delete keyword to remove identity from globals

### DIFF
--- a/src/commands/token/capability/worker.js
+++ b/src/commands/token/capability/worker.js
@@ -106,8 +106,7 @@ class WorkerCapabilityTokenGenerator extends TwilioClientCommand {
 	}
 }
 
-const globals = { ...globalFlags };
-delete globals.identity;
+const {_identity, globals} = { ...globalFlags };
 
 WorkerCapabilityTokenGenerator.flags = Object.assign(
 	taskrouterFlags,

--- a/src/commands/token/flex.js
+++ b/src/commands/token/flex.js
@@ -48,8 +48,7 @@ class FlexTokenGenerator extends TwilioClientCommand {
 	}
 }
 
-const globals = { ...globalFlags };
-delete globals.identity;
+const {_identity, globals} = { ...globalFlags };
 
 FlexTokenGenerator.flags = Object.assign(
 	taskrouterFlags,


### PR DESCRIPTION
<!-- Describe your Pull Request -->

This commit replaces the `delete globals.identity` line in the `flex.js` and `worker.js` commands with a destructuring assignment. This is compatible with the project's biome `noDelete` setting.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
