### PR TITLE
Fix biome issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,17 +29,13 @@
 		"/yarn.lock"
 	],
 	"homepage": "https://github.com/twilio-labs/plugin-token",
-	"keywords": [
-		"oclif-plugin"
-	],
+	"keywords": ["oclif-plugin"],
 	"license": "MIT",
 	"oclif": {
 		"name": "token",
 		"commands": "./src/commands",
 		"bin": "twilio",
-		"devPlugins": [
-			"@oclif/plugin-help"
-		],
+		"devPlugins": ["@oclif/plugin-help"],
 		"topics": {
 			"token": {
 				"description": "Generate a temporary token for use in test applications"

--- a/src/commands/token/capability/worker.js
+++ b/src/commands/token/capability/worker.js
@@ -106,7 +106,7 @@ class WorkerCapabilityTokenGenerator extends TwilioClientCommand {
 	}
 }
 
-const {_identity, globals} = { ...globalFlags };
+const { _identity, globals } = { ...globalFlags };
 
 WorkerCapabilityTokenGenerator.flags = Object.assign(
 	taskrouterFlags,

--- a/src/commands/token/capability/worker.js
+++ b/src/commands/token/capability/worker.js
@@ -106,8 +106,7 @@ class WorkerCapabilityTokenGenerator extends TwilioClientCommand {
 	}
 }
 
-const globals = { ...globalFlags };
-delete globals.identity;
+const {_identity, globals} = { ...globalFlags };
 
 WorkerCapabilityTokenGenerator.flags = Object.assign(
 	taskrouterFlags,

--- a/src/commands/token/flex.js
+++ b/src/commands/token/flex.js
@@ -48,8 +48,7 @@ class FlexTokenGenerator extends TwilioClientCommand {
 	}
 }
 
-const globals = { ...globalFlags };
-delete globals.identity;
+const {_identity, globals} = { ...globalFlags };
 
 FlexTokenGenerator.flags = Object.assign(
 	taskrouterFlags,

--- a/src/commands/token/flex.js
+++ b/src/commands/token/flex.js
@@ -48,7 +48,7 @@ class FlexTokenGenerator extends TwilioClientCommand {
 	}
 }
 
-const {_identity, globals} = { ...globalFlags };
+const { _identity, globals } = { ...globalFlags };
 
 FlexTokenGenerator.flags = Object.assign(
 	taskrouterFlags,


### PR DESCRIPTION
<!-- Describe your Pull Request -->

This commit 1) replaces the delete globals.identity line in the flex.js and worker.js commands with a destructuring assignment and 2) re-formats `package.json`. This is compatible with the project's biome settings.



**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
